### PR TITLE
Fix code example in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ import embed_anything
 data = embed_anything.embed_directory("directory_path", embeder= "Clip")
 embeddings = np.array([data.embedding for data in data])
 
-query = "photo of a dog"
+query = ["photo of a dog"]
 query_embedding = np.array(embed_anything.embed_query(query, embeder= "Clip")[0].embedding)
 similarities = np.dot(embeddings, query_embedding)
 max_index = np.argmax(similarities)


### PR DESCRIPTION
Hi,

I noticed a minor issue in the code example provided in the README file. The query parameter should be a list. I tried running the 'before' code, but it didn't work as expected and produced the following error:

```

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[5], line 2
      1 query = "photo of a car"
----> 2 query_embedding = np.array(embed_anything.embed_query(query, embeder= "Clip")[0].embedding)
      3 similarities = np.dot(embeddings, query_embedding)
      4 print(similarities)

TypeError: argument 'query': Can't extract `str` to `Vec`
```

After changing the query to a list, the code worked correctly.

Changes Made:
Changed the query string to a list in the example code.

Before:
```
import embed_anything
data = embed_anything.embed_directory("directory_path", embeder= "Clip")
embeddings = np.array([data.embedding for data in data])

query = "photo of a dog"
query_embedding = np.array(embed_anything.embed_query(query, embeder= "Clip")[0].embedding)
similarities = np.dot(embeddings, query_embedding)
max_index = np.argmax(similarities)
Image.open(data[max_index].text).show()
```
After:
```
import embed_anything
data = embed_anything.embed_directory("directory_path", embeder= "Clip")
embeddings = np.array([data.embedding for data in data])

query = ["photo of a dog"]
query_embedding = np.array(embed_anything.embed_query(query, embeder= "Clip")[0].embedding)
similarities = np.dot(embeddings, query_embedding)
max_index = np.argmax(similarities)
Image.open(data[max_index].text).show()
```

Thank you for considering this fix.