### PR TITLE
Create HtmlProcessor

### DIFF
--- a/rust/src/file_processor/html_processor.rs
+++ b/rust/src/file_processor/html_processor.rs
@@ -143,8 +143,9 @@ impl HtmlProcessor {
         let headers = self.get_text_from_tag("h1,h2,h3", &document)?;
         let paragraphs = self.get_text_from_tag("p", &document)?;
         let codes = self.get_text_from_tag("code", &document)?;
+        let origin = origin.map(Into::into);
         let links = match &origin {
-            Some(origin) => Some(self.extract_links(origin, &document)?),
+            Some(origin) => Some(self.extract_links(&origin.clone(), &document)?),
             None => None
         };
         let title = self.get_title(&document)?;
@@ -168,9 +169,9 @@ impl HtmlProcessor {
             .collect())
     }
 
-    fn extract_links(&self, website: impl Into<String>, document: &Html) -> Result<HashSet<String>> {
+    fn extract_links(&self, website: &str, document: &Html) -> Result<HashSet<String>> {
         let mut links = HashSet::new();
-        let base_url = Url::parse(&website.into())?;
+        let base_url = Url::parse(&website)?;
 
         for element in document.select(&Selector::parse("a").expect("invalid selector for link")) {
             if let Some(href) = element.value().attr("href") {

--- a/rust/src/file_processor/html_processor.rs
+++ b/rust/src/file_processor/html_processor.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+use std::collections::HashSet;
+use scraper::{Html, Selector};
+use url::Url;
+
+#[derive(Debug)]
+pub struct HtmlDocument {
+    pub title: Option<String>,
+    pub headers: Option<Vec<String>>,
+    pub paragraphs: Option<Vec<String>>,
+    pub codes: Option<Vec<String>>,
+    pub links: Option<HashSet<String>>,
+}
+
+/// A Struct for processing HTML files.
+pub struct HtmlProcessor;
+
+impl HtmlProcessor {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Extracts the contents of an HTML file.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `file_path` - The path to the HTML file.
+    /// * `origin` - The original URL of the HTML page, if any. This is required for extracting links.
+    /// 
+    /// # Returns
+    /// 
+    /// Returns a `Result` containing the extracted content as an `HtmlDocument` if successful,
+    /// or an `Error` if an error occurred during any part of the process.
+    pub fn process_html_file(&self, file_path: impl AsRef<std::path::Path>, origin: Option<impl Into<String>>) -> Result<HtmlDocument> {
+        // check if https is in the website. If not, add it.
+        let bytes = std::fs::read(file_path)?;
+        let out = String::from_utf8_lossy(&bytes);
+        self.process_html(out, origin)
+    }
+
+    /// Extracts the contents of an HTML text.
+    ///
+    /// # Arguments
+    ///
+    /// * `html` - The HTML text to be extracted.
+    /// * `origin` - The original URL of the HTML, if any. This is required for extracting links.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the extracted content as an `HtmlDocument` if successful,
+    /// or an `Error` if an error occurred during any part of the process.
+    pub fn process_html(&self, html: impl Into<String>, origin: Option<impl Into<String>>) -> Result<HtmlDocument> {
+        // check if https is in the website. If not, add it.
+        let document = Html::parse_document(&html.into());
+        let headers = self.get_text_from_tag("h1,h2,h3", &document)?;
+        let paragraphs = self.get_text_from_tag("p", &document)?;
+        let codes = self.get_text_from_tag("code", &document)?;
+        let links = match origin {
+            Some(origin) => Some(self.extract_links(origin, &document)?),
+            None => None
+        };
+        let title = self.get_title(&document)?;
+        let web_page = HtmlDocument {
+            title,
+            headers: Some(headers),
+            paragraphs: Some(paragraphs),
+            codes: Some(codes),
+            links,
+        };
+
+        Ok(web_page)
+    }
+
+    fn get_text_from_tag(&self, tag: &str, document: &Html) -> Result<Vec<String>> {
+        let selector = Selector::parse(tag).expect("invalid selector for tag");
+        Ok(document
+            .select(&selector)
+            .map(|element| element.text().collect::<String>().trim().to_string())
+            .collect())
+    }
+
+    fn extract_links(&self, website: impl Into<String>, document: &Html) -> Result<HashSet<String>> {
+        let mut links = HashSet::new();
+        let base_url = Url::parse(&website.into())?;
+
+        for element in document.select(&Selector::parse("a").expect("invalid selector for link")) {
+            if let Some(href) = element.value().attr("href") {
+                let mut link_url = base_url.join(href)?;
+                // Normalize URLs, remove fragments and ensure they are absolute.
+                link_url.set_fragment(None);
+                links.insert(link_url.to_string());
+            }
+        }
+
+        Ok(links)
+    }
+
+    fn get_title(&self, document: &Html) -> Result<Option<String>> {
+        if let Some(title_element) = document.select(&Selector::parse("title").expect("invalid selector for title")).next() {
+            Ok(Some(title_element.text().collect::<String>()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_html_file() {
+        let html_processor = HtmlProcessor::new();
+        let html_file = "test_files/test.html";
+        let result = html_processor.process_html_file(html_file, Some("https://example.com/"));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_process_html_file_err() {
+        let html_processor = HtmlProcessor::new();
+        let html_file = "test_files/some_file_that_doesnt_exist.html";
+        let result = html_processor.process_html_file(html_file, Some("https://example.com/"));
+        assert!(result.is_err());
+    }
+}

--- a/rust/src/file_processor/mod.rs
+++ b/rust/src/file_processor/mod.rs
@@ -10,4 +10,7 @@ pub mod txt_processor;
 /// This module contains the processor to process web links.
 pub mod website_processor;
 
+/// This module contains the file processor for HTML files.
+pub mod html_processor;
+
 pub mod audio;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -236,7 +236,7 @@ where
 /// ```
 pub async fn embed_html(
     file_name: impl AsRef<std::path::Path>,
-    origin: Option<impl From<String>>,
+    origin: Option<impl Into<String>>,
     embedder: &Embedder,
     config: Option<&TextEmbedConfig>,
     // Callback function

--- a/test_files/test.html
+++ b/test_files/test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>My First Heading</h1>
+
+<p>My first paragraph.</p>
+
+</body>
+</html>


### PR DESCRIPTION
This separates HTML parsing from website loading, allowing users to parse HTML documents that have already been downloaded.
Resolves #92 