### PR TITLE
Rewrite Rust documentation - part 1

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -2,14 +2,56 @@ use std::sync::Arc;
 
 use crate::{embeddings::embed::Embedder, text_loader::SplittingStrategy};
 
+/// Configuration for text embedding.
+///
+/// # Example: Creating a new instance
+///
+/// ```rust
+/// use embed_anything::config::TextEmbedConfig;
+/// use embed_anything::text_loader::SplittingStrategy;
+/// let config = TextEmbedConfig::new(
+///     Some(512),
+///     Some(128),
+///     Some(100),
+///     Some(0.0),
+///     Some(SplittingStrategy::Sentence),
+///     None,
+///     Some(true)
+/// );
+/// ```
+///
+/// # Example: Overriding a single default
+///
+/// ```rust
+/// use embed_anything::config::TextEmbedConfig;
+/// use embed_anything::text_loader::SplittingStrategy;
+/// let config = TextEmbedConfig {
+///     splitting_strategy: Some(SplittingStrategy::Semantic),
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Clone)]
 pub struct TextEmbedConfig {
+    /// Controls the size of each "chunk" of data that your input text gets split into. Defaults to
+    /// 256.
     pub chunk_size: Option<usize>,
+    /// Controls the ratio of overlapping data across "chunks" of your input text. Defaults to 0.0,
+    /// or no overlap.
     pub overlap_ratio: Option<f32>,
+    /// Controls the size of each "batch" of data sent to the embedder. The default value depends
+    /// largely on the embedder, but will be set to 32 when using [TextEmbedConfig::default()]
     pub batch_size: Option<usize>,
-    pub buffer_size: Option<usize>, // Required for adapter. Default is 100.
+    /// When using an adapter, this controls the size of the buffer. Defaults to 100.
+    pub buffer_size: Option<usize>,
+    /// Controls how documents are split into segments. See [SplittingStrategy] for options.
+    /// Defaults to [SplittingStrategy::Sentence]
     pub splitting_strategy: Option<SplittingStrategy>,
+    /// Allows overriding the embedder used when the splitting strategy is
+    /// [SplittingStrategy::Semantic]. Defaults to JINA.
     pub semantic_encoder: Option<Arc<Embedder>>,
+    /// When embedding a PDF, controls whether **o**ptical **c**haracter **r**ecognition is used on
+    /// the PDF to extract text. This process involves rendering the PDF as a series of images, and
+    /// extracting text from the images. Defaults to false.
     pub use_ocr: Option<bool>,
     pub tesseract_path: Option<String>,
 }

--- a/rust/src/embeddings/cloud/cohere.rs
+++ b/rust/src/embeddings/cloud/cohere.rs
@@ -36,7 +36,7 @@ impl CohereEmbedder {
     ///
     /// # Arguments
     ///
-    /// * `model` - A string slice that holds the model to be used for embedding. Find available models at https://docs.cohere.com/docs/cohere-embed
+    /// * `model` - A string slice that holds the model to be used for embedding. Find available models at <https://docs.cohere.com/docs/cohere-embed>
     /// * `api_key` - An optional string slice that holds the API key for authenticating requests to the Cohere API.
     ///
     /// # Returns

--- a/rust/src/embeddings/embed.rs
+++ b/rust/src/embeddings/embed.rs
@@ -205,8 +205,8 @@ impl TextEmbedder {
     ///             - "cohere"
     ///
     /// * `model_id` - A string holds the model ID for the model to be used for embedding.
-    ///     - For OpenAI, find available models at https://platform.openai.com/docs/guides/embeddings/embedding-models
-    ///     - For Cohere, find available models at https://docs.cohere.com/docs/cohere-embed
+    ///     - For OpenAI, find available models at <https://platform.openai.com/docs/guides/embeddings/embedding-models>
+    ///     - For Cohere, find available models at <https://docs.cohere.com/docs/cohere-embed>
     /// * `api_key` - An optional string holds the API key for authenticating requests to the Cohere API. If not provided, it is taken from the environment variable
     ///         - For OpenAI, create environment variable `OPENAI_API_KEY`
     ///         - For Cohere, create environment variable `CO_API_KEY`

--- a/rust/src/models/clip/mod.rs
+++ b/rust/src/models/clip/mod.rs
@@ -3,8 +3,8 @@
 //! Contrastive Language-Image Pre-Training (CLIP) is an architecture trained on
 //! pairs of images with related texts.
 //!
-//! https://github.com/openai/CLIP
-//! https://github.com/huggingface/transformers/tree/f6fa0f0bf0796ac66f201f23bdb8585de1609add/src/transformers/models/clip
+//! <https://github.com/openai/CLIP>
+//! <https://github.com/huggingface/transformers/tree/f6fa0f0bf0796ac66f201f23bdb8585de1609add/src/transformers/models/clip>
 use self::{
     text_model::{Activation, ClipTextTransformer},
     vision_model::ClipVisionTransformer,

--- a/rust/src/models/clip/text_model.rs
+++ b/rust/src/models/clip/text_model.rs
@@ -3,8 +3,8 @@
 //! Contrastive Language-Image Pre-Training (CLIP) is an architecture trained on
 //! pairs of images with related texts.
 //!
-//! https://github.com/openai/CLIP
-//! https://github.com/huggingface/transformers/tree/f6fa0f0bf0796ac66f201f23bdb8585de1609add/src/transformers/models/clip
+//! <https://github.com/openai/CLIP>
+//! <https://github.com/huggingface/transformers/tree/f6fa0f0bf0796ac66f201f23bdb8585de1609add/src/transformers/models/clip>
 
 use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
 use candle_nn as nn;

--- a/rust/src/models/clip/vision_model.rs
+++ b/rust/src/models/clip/vision_model.rs
@@ -3,8 +3,8 @@
 //! Contrastive Language-Image Pre-Training (CLIP) is an architecture trained on
 //! pairs of images with related texts.
 //!
-//! https://github.com/openai/CLIP
-//! https://github.com/huggingface/transformers/tree/f6fa0f0bf0796ac66f201f23bdb8585de1609add/src/transformers/models/clip
+//! <https://github.com/openai/CLIP>
+//! <https://github.com/huggingface/transformers/tree/f6fa0f0bf0796ac66f201f23bdb8585de1609add/src/transformers/models/clip>
 
 use candle_core::{IndexOp, Result, Shape, Tensor, D};
 use candle_nn as nn;


### PR DESCRIPTION
This brings essentially all of `lib.rs` (including crate docs) to what I feel is a pretty good place. I'm sure there's room for improvement, and there's certainly more to document beyond there, but the main page should look pretty good now 😄 