### PR TITLE
Make SplittingStrategy::Semantic require an encoder

### DIFF
--- a/python/src/config.rs
+++ b/python/src/config.rs
@@ -1,8 +1,5 @@
-use std::sync::Arc;
-
-use embed_anything::text_loader::SplittingStrategy;
 use pyo3::prelude::*;
-
+use embed_anything::config::SplittingStrategy;
 use crate::EmbeddingModel;
 
 #[pyclass]
@@ -27,23 +24,26 @@ impl TextEmbedConfig {
     ) -> Self {
         let strategy = match splitting_strategy {
             Some(strategy) => match strategy {
-                "sentence" => Some(SplittingStrategy::Sentence),
-                "semantic" => Some(SplittingStrategy::Semantic),
-                _ => None,
+                "sentence" => SplittingStrategy::Sentence,
+                "semantic" => {
+                    if semantic_encoder.is_none() {
+                        panic!("Semantic encoder is required when using Semantic splitting strategy");
+                    }
+                    SplittingStrategy::Semantic {
+                        semantic_encoder: semantic_encoder.unwrap().inner.clone()
+                    }
+                },
+                _ => panic!("Unknown strategy provided!"),
             },
-            None => None,
+            None => SplittingStrategy::Sentence,
         };
-        let semantic_encoder = semantic_encoder.map(|model| Arc::clone(&model.inner));
-        if matches!(strategy, Some(SplittingStrategy::Semantic)) && semantic_encoder.is_none() {
-            panic!("Semantic encoder is required when using Semantic splitting strategy");
-        }
+
         Self {
             inner: embed_anything::config::TextEmbedConfig::default()
                 .with_chunk_size(chunk_size.unwrap_or(256), overlap_ratio)
                 .with_batch_size(batch_size.unwrap_or(32))
                 .with_buffer_size(buffer_size.unwrap_or(100))
-                .with_splitting_strategy(strategy.unwrap_or(SplittingStrategy::Sentence))
-                .with_semantic_encoder(semantic_encoder)
+                .with_splitting_strategy(strategy)
                 .with_ocr(use_ocr.unwrap_or(false), tesseract_path)
         }
     }

--- a/rust/src/file_processor/html_processor.rs
+++ b/rust/src/file_processor/html_processor.rs
@@ -1,12 +1,13 @@
 use crate::embeddings::embed::{EmbedData, Embedder};
 use crate::embeddings::get_text_metadata;
-use crate::text_loader::{SplittingStrategy, TextLoader};
+use crate::text_loader::TextLoader;
 use anyhow::Result;
 use scraper::{Html, Selector};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use url::Url;
+use crate::config::SplittingStrategy;
 
 #[derive(Debug)]
 pub struct HtmlDocument {
@@ -87,7 +88,7 @@ impl HtmlDocument {
         for content in tag_content {
             let textloader = TextLoader::new(chunk_size, overlap_ratio);
             let chunks =
-                match textloader.split_into_chunks(content, SplittingStrategy::Sentence, None) {
+                match textloader.split_into_chunks(content, SplittingStrategy::Sentence) {
                     Some(chunks) => chunks,
                     None => continue,
                 };

--- a/rust/src/file_processor/website_processor.rs
+++ b/rust/src/file_processor/website_processor.rs
@@ -12,8 +12,9 @@ use crate::{
         get_text_metadata,
     },
     file_processor::html_processor::HtmlProcessor,
-    text_loader::{SplittingStrategy, TextLoader},
+    text_loader::TextLoader,
 };
+use crate::config::SplittingStrategy;
 
 #[derive(Debug)]
 pub struct WebPage {
@@ -94,7 +95,7 @@ impl WebPage {
         for content in tag_content {
             let textloader = TextLoader::new(chunk_size, overlap_ratio);
             let chunks =
-                match textloader.split_into_chunks(content, SplittingStrategy::Sentence, None) {
+                match textloader.split_into_chunks(content, SplittingStrategy::Sentence) {
                     Some(chunks) => chunks,
                     None => continue,
                 };

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -80,12 +80,13 @@ use file_loader::FileParser;
 use file_processor::audio::audio_processor::AudioDecoderModel;
 use itertools::Itertools;
 use rayon::prelude::*;
-use text_loader::{SplittingStrategy, TextLoader};
+use text_loader::TextLoader;
 use tokio::sync::mpsc; // Add this at the top of your file
 
 
 #[cfg(feature = "audio")]
 use embeddings::embed_audio;
+use crate::config::SplittingStrategy;
 
 pub enum Dtype {
     F16,
@@ -336,10 +337,7 @@ where
     let chunk_size = config.chunk_size.unwrap_or(256);
     let overlap_ratio = config.overlap_ratio.unwrap_or(0.0);
     let batch_size = config.batch_size;
-    let splitting_strategy = config
-        .splitting_strategy
-        .unwrap_or(SplittingStrategy::Sentence);
-    let semantic_encoder = config.semantic_encoder.clone();
+    let splitting_strategy = config.splitting_strategy.clone();
     let use_ocr = config.use_ocr.unwrap_or(false);
     let tesseract_path = config.tesseract_path.clone();
     let text = TextLoader::extract_text(&file, use_ocr, tesseract_path.as_deref())?;
@@ -348,7 +346,6 @@ where
         .split_into_chunks(
             &text,
             splitting_strategy,
-            semantic_encoder,
         )
         .unwrap_or_default();
 
@@ -723,7 +720,7 @@ where
             }
         };
         let chunks = textloader
-            .split_into_chunks(&text, SplittingStrategy::Sentence, None)
+            .split_into_chunks(&text, SplittingStrategy::Sentence)
             .unwrap_or_else(|| vec![text.clone()])
             .into_iter()
             .filter(|chunk| !chunk.trim().is_empty())


### PR DESCRIPTION
Previously if you didn't specify an encoder separately you'd get a runtime exception. It's now required at compile time instead.

I was originally hoping to also set the default to Jina, but Rust doesn't support default values for fields and it didn't seem like a good idea to set the default SplittingStrategy to Semantic in general.