### PR TITLE
Embed HTML into Markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,7 @@ dependencies = [
  "futures",
  "half",
  "hf-hub",
+ "htmd",
  "image",
  "indicatif",
  "intel-mkl-src",
@@ -1880,6 +1881,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmd"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1642def6e8e4dc182941f35454f7d2af917787f91f3f5133300030b41006d0"
+dependencies = [
+ "html5ever 0.27.0",
+ "markup5ever_rcdom",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,7 +1912,7 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.14.1",
  "match_token",
 ]
 
@@ -2559,6 +2584,20 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
@@ -2569,6 +2608,18 @@ dependencies = [
  "string_cache",
  "string_cache_codegen",
  "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
+dependencies = [
+ "html5ever 0.27.0",
+ "markup5ever 0.12.1",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -4167,7 +4218,7 @@ dependencies = [
  "cssparser",
  "ego-tree",
  "getopts",
- "html5ever",
+ "html5ever 0.29.1",
  "precomputed-hash",
  "selectors",
  "tendril",
@@ -5801,6 +5852,17 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,29 +791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cssparser"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "cudarc"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,21 +987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,12 +1010,6 @@ checksum = "490bd48eb68fffcfed519b4edbfd82c69cbe741d175b84f0e0cbe8c57cbe0bdd"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "ego-tree"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -1096,7 +1052,6 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "scraper",
  "serde",
  "serde_json",
  "statistical",
@@ -1467,15 +1422,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1886,7 +1832,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1642def6e8e4dc182941f35454f7d2af917787f91f3f5133300030b41006d0"
 dependencies = [
- "html5ever 0.27.0",
+ "html5ever",
  "markup5ever_rcdom",
 ]
 
@@ -1898,22 +1844,10 @@ checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
 dependencies = [
  "log",
  "mac",
- "markup5ever 0.12.1",
+ "markup5ever",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.14.1",
- "match_token",
 ]
 
 [[package]]
@@ -2597,40 +2531,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "markup5ever"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
-dependencies = [
- "log",
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
- "tendril",
-]
-
-[[package]]
 name = "markup5ever_rcdom"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
 dependencies = [
- "html5ever 0.27.0",
- "markup5ever 0.12.1",
+ "html5ever",
+ "markup5ever",
  "tendril",
  "xml5ever",
-]
-
-[[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -3241,7 +3150,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
  "phf_shared 0.11.3",
 ]
 
@@ -3273,19 +3181,6 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -4210,40 +4105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scraper"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
-dependencies = [
- "cssparser",
- "ego-tree",
- "getopts",
- "html5ever 0.29.1",
- "precomputed-hash",
- "selectors",
- "tendril",
-]
-
-[[package]]
-name = "selectors"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
-dependencies = [
- "bitflags 2.8.0",
- "cssparser",
- "derive_more",
- "fxhash",
- "log",
- "new_debug_unreachable",
- "phf",
- "phf_codegen",
- "precomputed-hash",
- "servo_arc",
- "smallvec",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4315,15 +4176,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae65c4249478a2647db249fb43e23cec56a2c8974a427e7bd8cb5a1d0964921a"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -5862,7 +5714,7 @@ checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
 dependencies = [
  "log",
  "mac",
- "markup5ever 0.12.1",
+ "markup5ever",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -51,7 +51,8 @@ tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
 # Markdown Processing
 markdown_to_text = "1.0.0"
 
-# Web Scraping
+# HTML processing
+htmd = "0.1.6"
 scraper = "0.22.0"
 
 # Text Processing

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -53,7 +53,6 @@ markdown_to_text = "1.0.0"
 
 # HTML processing
 htmd = "0.1.6"
-scraper = "0.22.0"
 
 # Text Processing
 url = "2.5.0"

--- a/rust/src/embeddings/embed.rs
+++ b/rust/src/embeddings/embed.rs
@@ -662,7 +662,7 @@ impl Embedder {
     ///         .from_pretrained_hf()
     ///         .unwrap());
     ///     let config = TextEmbedConfig::default();
-    ///     let embeddings = embedder.embed_files_batch(files, Some(&config), None::<fn(Vec<EmbedData>)>).await.unwrap();
+    ///     let embeddings = embedder.embed_files_batch(files, Some(&config), None).await.unwrap();
     /// }
     /// ```
     /// This will output the embeddings of the files in the specified directory using the specified embedding model.
@@ -690,16 +690,6 @@ impl Embedder {
         adapter: Option<Box<dyn FnOnce(Vec<EmbedData>) + Send + Sync>>,
     ) -> Result<Option<Vec<EmbedData>>> {
         crate::embed_webpage(url, self, config, adapter).await
-    }
-
-    pub async fn embed_html(
-        &self,
-        file_name: impl AsRef<std::path::Path>,
-        origin: Option<impl Into<String>>,
-        config: Option<&TextEmbedConfig>,
-        adapter: Option<Box<dyn FnOnce(Vec<EmbedData>) + Send + Sync>>,
-    ) -> Result<Option<Vec<EmbedData>>> {
-        crate::embed_html(file_name, self, origin, config, adapter).await
     }
 }
 

--- a/rust/src/file_processor/html_processor.rs
+++ b/rust/src/file_processor/html_processor.rs
@@ -1,140 +1,26 @@
-use crate::config::SplittingStrategy;
-use crate::embeddings::embed::{EmbedData, Embedder};
-use crate::embeddings::get_text_metadata;
-use crate::text_loader::TextLoader;
+use crate::file_processor::markdown_processor::MarkdownProcessor;
 use anyhow::Result;
-use scraper::{Html, Selector};
-use serde_json::json;
-use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
-use url::Url;
+use htmd::HtmlToMarkdown;
 
-#[derive(Debug)]
 pub struct HtmlDocument {
+    pub content: String,
     pub origin: Option<String>,
-    pub title: Option<String>,
-    pub headers: Option<Vec<String>>,
-    pub paragraphs: Option<Vec<String>>,
-    pub codes: Option<Vec<String>>,
-    pub links: Option<HashSet<String>>,
-}
-
-impl HtmlDocument {
-    pub async fn embed_webpage(
-        &self,
-        embedder: &Embedder,
-        chunk_size: usize,
-        overlap_ratio: f32,
-        batch_size: Option<usize>,
-    ) -> Result<Vec<EmbedData>> {
-        let mut embed_data = Vec::new();
-
-        if let Some(paragraphs) = &self.paragraphs {
-            embed_data.extend(
-                self.embed_tag(
-                    "p",
-                    paragraphs,
-                    embedder,
-                    chunk_size,
-                    overlap_ratio,
-                    batch_size,
-                )
-                .await?,
-            );
-        }
-
-        if let Some(headers) = &self.headers {
-            embed_data.extend(
-                self.embed_tag(
-                    "h1",
-                    headers,
-                    embedder,
-                    chunk_size,
-                    overlap_ratio,
-                    batch_size,
-                )
-                .await?,
-            );
-        }
-
-        if let Some(codes) = &self.codes {
-            embed_data.extend(
-                self.embed_tag(
-                    "code",
-                    codes,
-                    embedder,
-                    chunk_size,
-                    overlap_ratio,
-                    batch_size,
-                )
-                .await?,
-            );
-        }
-
-        Ok(embed_data)
-    }
-
-    pub async fn embed_tag(
-        &self,
-        tag: &str,
-        tag_content: &[String],
-        embedder: &Embedder,
-        chunk_size: usize,
-        overlap_ratio: f32,
-        batch_size: Option<usize>,
-    ) -> Result<Vec<EmbedData>> {
-        let mut embed_data = Vec::new();
-
-        for content in tag_content {
-            let textloader = TextLoader::new(chunk_size, overlap_ratio);
-            let chunks = match textloader.split_into_chunks(content, SplittingStrategy::Sentence) {
-                Some(chunks) => chunks,
-                None => continue,
-            };
-
-            if chunks.is_empty() {
-                continue;
-            }
-
-            let tag_type = match tag {
-                "h1" => "header",
-                "h2" => "subheader",
-                "h3" => "subsubheader",
-                "p" => "paragraph",
-                "code" => "code",
-                _ => "paragraph",
-            };
-
-            let metadata = json!({
-                "url": self.origin,
-                "type": tag_type,
-                "full_text": content,
-            });
-
-            let metadata_hashmap: HashMap<String, String> = serde_json::from_value(metadata)?;
-            let chunk_refs: Vec<&str> = chunks.iter().map(|s| s.as_str()).collect();
-            let encodings = embedder.embed(&chunk_refs, batch_size, None).await?;
-            let embeddings =
-                get_text_metadata(&Rc::new(encodings), &chunk_refs, &Some(metadata_hashmap))?;
-            embed_data.extend(embeddings);
-        }
-
-        Ok(embed_data)
-    }
 }
 
 /// A Struct for processing HTML files.
-pub struct HtmlProcessor;
+pub struct HtmlProcessor {
+    markdown_processor: MarkdownProcessor,
+}
 
 impl Default for HtmlProcessor {
     fn default() -> Self {
-        Self::new()
+        Self::new(MarkdownProcessor)
     }
 }
 
 impl HtmlProcessor {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(markdown_processor: MarkdownProcessor) -> Self {
+        Self { markdown_processor}
     }
 
     /// Extracts the contents of an HTML file.
@@ -151,7 +37,7 @@ impl HtmlProcessor {
     pub fn process_html_file(
         &self,
         file_path: impl AsRef<std::path::Path>,
-        origin: Option<impl Into<String>>,
+        origin: Option<&str>,
     ) -> Result<HtmlDocument> {
         // check if https is in the website. If not, add it.
         let bytes = std::fs::read(file_path)?;
@@ -175,62 +61,12 @@ impl HtmlProcessor {
         html: impl Into<String>,
         origin: Option<impl Into<String>>,
     ) -> Result<HtmlDocument> {
-        // check if https is in the website. If not, add it.
-        let document = Html::parse_document(&html.into());
-        let headers = self.get_text_from_tag("h1,h2,h3", &document)?;
-        let paragraphs = self.get_text_from_tag("p", &document)?;
-        let codes = self.get_text_from_tag("code", &document)?;
-        let origin = origin.map(Into::into);
-        let links = match &origin {
-            Some(origin) => Some(self.extract_links(&origin.clone(), &document)?),
-            None => None,
-        };
-        let title = self.get_title(&document)?;
-        let web_page = HtmlDocument {
-            origin,
-            title,
-            headers: Some(headers),
-            paragraphs: Some(paragraphs),
-            codes: Some(codes),
-            links,
-        };
-
-        Ok(web_page)
-    }
-
-    fn get_text_from_tag(&self, tag: &str, document: &Html) -> Result<Vec<String>> {
-        let selector = Selector::parse(tag).expect("invalid selector for tag");
-        Ok(document
-            .select(&selector)
-            .map(|element| element.text().collect::<String>().trim().to_string())
-            .collect())
-    }
-
-    fn extract_links(&self, website: &str, document: &Html) -> Result<HashSet<String>> {
-        let mut links = HashSet::new();
-        let base_url = Url::parse(website)?;
-
-        for element in document.select(&Selector::parse("a").expect("invalid selector for link")) {
-            if let Some(href) = element.value().attr("href") {
-                let mut link_url = base_url.join(href)?;
-                // Normalize URLs, remove fragments and ensure they are absolute.
-                link_url.set_fragment(None);
-                links.insert(link_url.to_string());
-            }
-        }
-
-        Ok(links)
-    }
-
-    fn get_title(&self, document: &Html) -> Result<Option<String>> {
-        if let Some(title_element) = document
-            .select(&Selector::parse("title").expect("invalid selector for title"))
-            .next()
-        {
-            Ok(Some(title_element.text().collect::<String>()))
-        } else {
-            Ok(None)
-        }
+        let content = HtmlToMarkdown::new().convert(&html.into())?;
+        let result = self.markdown_processor.process_markdown(content)?;
+        Ok(HtmlDocument {
+            content: result,
+            origin: origin.map(Into::into),
+        })
     }
 }
 
@@ -240,7 +76,7 @@ mod tests {
 
     #[test]
     fn test_process_html_file() {
-        let html_processor = HtmlProcessor::new();
+        let html_processor = HtmlProcessor::default();
         let html_file = "../test_files/test.html";
         let result = html_processor.process_html_file(html_file, Some("https://example.com/"));
         assert!(result.is_ok());
@@ -248,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_process_html_file_err() {
-        let html_processor = HtmlProcessor::new();
+        let html_processor = HtmlProcessor::default();
         let html_file = "../test_files/some_file_that_doesnt_exist.html";
         let result = html_processor.process_html_file(html_file, Some("https://example.com/"));
         assert!(result.is_err());

--- a/rust/src/file_processor/markdown_processor.rs
+++ b/rust/src/file_processor/markdown_processor.rs
@@ -17,7 +17,21 @@ impl MarkdownProcessor {
     pub fn extract_text<T: AsRef<std::path::Path>>(file_path: &T) -> Result<String, Error> {
         let bytes = std::fs::read(file_path)?;
         let out = String::from_utf8_lossy(&bytes).to_string();
-        let content = markdown_to_text::convert(&out);
+        Self::process_markdown(out)
+    }
+
+    /// Processes a Markdown-formatted String into a String ready for embedding.
+    ///
+    /// # Arguments
+    ///
+    /// * `markdown` - The Markdown text.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the extracted text content as a `String` if successful,
+    /// or an `Error` if an error occurred while reading the file or converting the Markdown.
+    pub fn process_markdown(markdown: String) -> Result<String, Error> {
+        let content = markdown_to_text::convert(&markdown);
         Ok(content)
     }
 }

--- a/rust/src/file_processor/markdown_processor.rs
+++ b/rust/src/file_processor/markdown_processor.rs
@@ -17,7 +17,7 @@ impl MarkdownProcessor {
     pub fn extract_text<T: AsRef<std::path::Path>>(file_path: &T) -> Result<String, Error> {
         let bytes = std::fs::read(file_path)?;
         let out = String::from_utf8_lossy(&bytes).to_string();
-        Self::process_markdown(out)
+        Self::process_markdown(&MarkdownProcessor, out)
     }
 
     /// Processes a Markdown-formatted String into a String ready for embedding.
@@ -30,7 +30,7 @@ impl MarkdownProcessor {
     ///
     /// Returns a `Result` containing the extracted text content as a `String` if successful,
     /// or an `Error` if an error occurred while reading the file or converting the Markdown.
-    pub fn process_markdown(markdown: String) -> Result<String, Error> {
+    pub fn process_markdown(&self, markdown: String) -> Result<String, Error> {
         let content = markdown_to_text::convert(&markdown);
         Ok(content)
     }

--- a/rust/src/file_processor/website_processor.rs
+++ b/rust/src/file_processor/website_processor.rs
@@ -1,146 +1,11 @@
-use std::{
-    collections::{HashMap, HashSet},
-    rc::Rc,
-};
-
 use anyhow::Result;
-use serde_json::json;
 
-use crate::config::SplittingStrategy;
-use crate::{
-    embeddings::{
-        embed::{EmbedData, Embedder},
-        get_text_metadata,
-    },
-    file_processor::html_processor::HtmlProcessor,
-    text_loader::TextLoader,
-};
+use crate::file_processor::html_processor::HtmlProcessor;
 
 #[derive(Debug)]
 pub struct WebPage {
     pub url: String,
-    pub title: Option<String>,
-    pub headers: Option<Vec<String>>,
-    pub paragraphs: Option<Vec<String>>,
-    pub codes: Option<Vec<String>>,
-    pub links: Option<HashSet<String>>,
-}
-
-impl WebPage {
-    pub async fn embed_webpage(
-        &self,
-        embedder: &Embedder,
-        chunk_size: usize,
-        overlap_ratio: f32,
-        batch_size: Option<usize>,
-    ) -> Result<Vec<EmbedData>> {
-        let mut embed_data = Vec::new();
-
-        if let Some(paragraphs) = &self.paragraphs {
-            embed_data.extend(
-                self.embed_tag(
-                    "p",
-                    paragraphs,
-                    embedder,
-                    chunk_size,
-                    overlap_ratio,
-                    batch_size,
-                )
-                .await?,
-            );
-        }
-
-        if let Some(headers) = &self.headers {
-            embed_data.extend(
-                self.embed_tag(
-                    "h1",
-                    headers,
-                    embedder,
-                    chunk_size,
-                    overlap_ratio,
-                    batch_size,
-                )
-                .await?,
-            );
-        }
-
-        if let Some(codes) = &self.codes {
-            embed_data.extend(
-                self.embed_tag(
-                    "code",
-                    codes,
-                    embedder,
-                    chunk_size,
-                    overlap_ratio,
-                    batch_size,
-                )
-                .await?,
-            );
-        }
-
-        Ok(embed_data)
-    }
-
-    pub async fn embed_tag(
-        &self,
-        tag: &str,
-        tag_content: &[String],
-        embedder: &Embedder,
-        chunk_size: usize,
-        overlap_ratio: f32,
-        batch_size: Option<usize>,
-    ) -> Result<Vec<EmbedData>> {
-        let mut embed_data = Vec::new();
-
-        for content in tag_content {
-            let textloader = TextLoader::new(chunk_size, overlap_ratio);
-            let chunks = match textloader.split_into_chunks(content, SplittingStrategy::Sentence) {
-                Some(chunks) => chunks,
-                None => continue,
-            };
-
-            if chunks.is_empty() {
-                continue;
-            }
-
-            let tag_type = match tag {
-                "h1" => "header",
-                "h2" => "subheader",
-                "h3" => "subsubheader",
-                "p" => "paragraph",
-                "code" => "code",
-                _ => "paragraph",
-            };
-
-            let metadata = json!({
-                "url": self.url,
-                "type": tag_type,
-                "full_text": content,
-            });
-
-            let metadata_hashmap: HashMap<String, String> = serde_json::from_value(metadata)?;
-            let chunk_refs: Vec<&str> = chunks.iter().map(|s| s.as_str()).collect();
-            let encodings = embedder.embed(&chunk_refs, batch_size, None).await?;
-            let embeddings =
-                get_text_metadata(&Rc::new(encodings), &chunk_refs, &Some(metadata_hashmap))?;
-            embed_data.extend(embeddings);
-        }
-
-        Ok(embed_data)
-    }
-}
-
-impl Default for WebPage {
-    fn default() -> Self {
-        Self {
-            url: "".to_string(),
-            title: None,
-            headers: None,
-            paragraphs: None,
-            codes: None,
-            links: None,
-        }
-    }
+    pub content: String,
 }
 
 impl Default for WebsiteProcessor {
@@ -156,7 +21,7 @@ pub struct WebsiteProcessor {
 impl WebsiteProcessor {
     pub fn new() -> Self {
         Self {
-            html_processor: HtmlProcessor::new(),
+            html_processor: HtmlProcessor::default(),
         }
     }
 
@@ -172,12 +37,8 @@ impl WebsiteProcessor {
         let html_document = self.html_processor.process_html(response, Some(website))?;
 
         let web_page = WebPage {
-            url: website.to_string(),
-            title: html_document.title,
-            headers: html_document.headers,
-            paragraphs: html_document.paragraphs,
-            codes: html_document.codes,
-            links: html_document.links,
+            url: html_document.origin.unwrap(), // We always have Some as per the above code
+            content: html_document.content,
         };
 
         Ok(web_page)

--- a/rust/src/text_loader.rs
+++ b/rust/src/text_loader.rs
@@ -14,6 +14,7 @@ use text_splitter::{Characters, ChunkConfig, TextSplitter};
 
 use super::file_processor::pdf_processor::PdfProcessor;
 use crate::config::SplittingStrategy;
+use crate::file_processor::html_processor::HtmlProcessor;
 
 impl Default for TextLoader {
     fn default() -> Self {
@@ -113,6 +114,7 @@ impl TextLoader {
             "md" => MarkdownProcessor::extract_text(file),
             "txt" => TxtProcessor::extract_text(file),
             "docx" => DocxProcessor::extract_text(file),
+            "html" => HtmlProcessor::default().process_html_file(file, None).map(|x| x.content),
             _ => Err(FileLoadingError::UnsupportedFileType(
                 file.as_ref()
                     .extension()


### PR DESCRIPTION
Splintered off #119 to get the changes done in smaller parts + resolving conflicts.

- Exposed `process_markdown` in `MarkdownProcessor`
- Rewrote `HtmlProcessor` to turn HTML into Markdown, and feed it into `MarkdownProcessor`
- Updated `WebsiteProcessor` to accommodate the new `HtmlProcessor` changes
- Removed `embed_html` function and added `html` support to `embed_file`