### PR TITLE
refactor: migrate milvus integration to MilvusClient API

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ We currently support a wide range of vector databases for streaming embeddings, 
 - Weaviate <br/>
 - Pinecone <br/>
 - Qdrant <br/>
+- Milvus<br/>
 
 How to add an adpters: https://starlight-search.com/blog/2024/02/25/adapter-development-guide.md
 

--- a/docs/guides/adapters.md
+++ b/docs/guides/adapters.md
@@ -46,3 +46,15 @@ pip install qdrant-client
 ``` python
 --8<-- "examples/adapters/qdrant.py"
 ```
+
+## Using Milvus
+
+To use [Milvus](https://milvus.io/), you need to install the `pymilvus` package.
+
+```bash
+pip install pymilvus
+```
+
+``` python
+--8<-- "examples/adapters/milvus_db.py"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -414,6 +414,7 @@ We currently support a wide range of vector databases for streaming embeddings, 
 - Weaviate<br/>
 - Pinecone<br/>
 - Qdrant<br/>
+- Milvus<br/>
 
 How to add an adpters: https://starlight-search.com/blog/2024/02/25/adapter-development-guide.md
 

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -70,6 +70,7 @@ We currently support a wide range of vector databases for streaming embeddings, 
 - Weaviate<br/>
 - Pinecone<br/>
 - Qdrant<br/>
+- Milvus<br/>
 
 But we're not stopping there! We're actively working to expand this list.
 


### PR DESCRIPTION
## Overview
This PR updates the Milvus vector database adapter to use the new MilvusClient API and adds support for Milvus Lite mode. 

## Key Changes
- Migrated from legacy pymilvus API to new MilvusClient interface
- Added support for Milvus Lite
- Improved schema and index creation methods
- Enhanced documentation with usage examples for both modes

## Usage Examples

### Milvus Lite 
```python
adapter = MilvusVectorAdapter(
    uri='./milvus.db',  # Milvus-Lite
    collection_name='embed_anything_collection'
)
```

### Milvus Standalone / Zilliz Cloud
```python
adapter = MilvusVectorAdapter(
    uri='http://localhost:19530',  # Milvus server address
    token='your_token',  # Optional authentication token
    collection_name='embed_anything_collection'
)
```
### Entire Workflow

```python
# Initialize adapter
adapter = MilvusVectorAdapter(uri='./milvus.db')

# Create index with specific dimension
adapter.create_index(dimension=384)

# Initialize embedding model
model = EmbeddingModel.from_pretrained_hf(
    WhichModel.Bert,
    model_id="sentence-transformers/all-MiniLM-L12-v2"
)

# Embed and store data
data = embed_anything.embed_file(
    "path/to/file",
    embedder=model,
    adapter=adapter
)
```
