### PR TITLE
Fix model_id argument position in Rust ColBERT example.

### DIFF
--- a/rust/examples/colbert.rs
+++ b/rust/examples/colbert.rs
@@ -1,5 +1,5 @@
 use embed_anything::config::{SplittingStrategy, TextEmbedConfig};
-use embed_anything::embeddings::embed::Embedder;
+use embed_anything::embeddings::embed::{Embedder, EmbeddingResult};
 use embed_anything::{embed_file, embed_query};
 use rayon::prelude::*;
 use std::sync::Arc;
@@ -12,8 +12,8 @@ async fn main() -> Result<(), anyhow::Error> {
             "colbert",
             // Some(ONNXModel::ModernBERTBase),
             None,
-            Some("answerdotai/answerai-colbert-small-v1"),
             None,
+            Some("answerdotai/answerai-colbert-small-v1"),
             None,
             Some("onnx/model_fp16.onnx"),
         )
@@ -55,9 +55,17 @@ async fn main() -> Result<(), anyhow::Error> {
         "मैं पिज्जा पसंद करता हूं", // Hindi for "I like pizza"
     ];
 
-    let _doc_embeddings = embed_query(&sentences, &model, Some(&config))
+    let doc_embeddings = embed_query(&sentences, &model, Some(&config))
         .await
         .unwrap();
+
+    // print out the embeddings for the first sentence
+    let EmbeddingResult::MultiVector(vec) = doc_embeddings[0].embedding.clone() else {
+        panic!("output should be a multi vector");
+    };
+    for (i, v) in vec.iter().enumerate() {
+        println!("{}: {:?}", i, v);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Previously an example run would output:

```
$ cargo run --example colbert
   Compiling embed_anything v0.5.5 (/Users/wesc/src/EmbedAnything/rust)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
     Running `target/debug/examples/colbert`
thread 'main' panicked at rust/examples/colbert.rs:20:10:
called `Result::unwrap()` on an `Err` value: Please provide either model_name or model_id
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Due to `answerdotai/answerai-colbert-small-v1` being in the wrong argument position. This PR fixes that and also adds a bit of debug output for extra illustration.