### PR TITLE
fix: replace hardcoded local PDF path with placeholder in Milvus adapter example

### DIFF
--- a/examples/adapters/milvus_db.py
+++ b/examples/adapters/milvus_db.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
 
     # Embed a PDF file
     data = embed_anything.embed_file(
-        "/Users/jinhonglin/Desktop/sample.pdf",
+        "path/to/your/file.pdf",
         embedder=model,
         adapter=milvus_adapter,
     )


### PR DESCRIPTION
### Description

This PR updates the `examples/adapters/milvus_db.py` file by replacing the hardcoded local path:

```python
"/Users/jinhonglin/Desktop/sample.pdf"
```

with a more generic placeholder:

```python
"path/to/your/file.pdf"
```

This prevents leaking personal file paths and makes the example more portable and user-friendly for contributors and users trying to adapt the code.

