### PR TITLE
feat: Upgrade model2vec-rs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "model2vec-rs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70002218ffccf2ffb3e8f8f203447271f3715845cdb208dc3bc71ecea602645e"
+checksum = "a837540cf6d048fd9dd7e182b7e565fc789da437f06da6dbbd385eea1dc6d72a"
 dependencies = [
  "anyhow",
  "clap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -68,7 +68,7 @@ indicatif = "0.17.8"
 statistical = "1.0.0"
 half = "2.4.1"
 candle-flash-attn = { workspace = true, optional = true }
-model2vec-rs = "0.1.0"
+model2vec-rs = "0.1.1"
 
 # Logging
 log = "0.4"


### PR DESCRIPTION
Hi!

This PR bumps the version of [model2vec-rs](https://github.com/MinishLab/model2vec-rs) from 0.1.0 to 0.1.1. We released a bugfix in this PR that fixes a compatibility issue with some models (including our newest multilingual model). Full changelog can be found [here](https://github.com/MinishLab/model2vec-rs/releases/tag/v0.1.1).