### PR TITLE
Fix: Support `HF_HOME` and `HF_ENDPOINT`

### DIFF
--- a/rust/src/embeddings/local/clip.rs
+++ b/rust/src/embeddings/local/clip.rs
@@ -203,7 +203,7 @@ impl ClipEmbedder {
     ) -> anyhow::Result<Tokenizer> {
         let tokenizer = match tokenizer {
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::api::sync::ApiBuilder::from_env().build()?;
                 let api = match revision {
                     Some(rev) => api.repo(hf_hub::Repo::with_revision(
                         model_id,

--- a/rust/src/embeddings/local/colbert.rs
+++ b/rust/src/embeddings/local/colbert.rs
@@ -7,7 +7,7 @@ extern crate accelerate_src;
 use std::{ops::Mul, sync::RwLock};
 
 use anyhow::{Error as E, Result};
-use hf_hub::{api::sync::Api, Repo};
+use hf_hub::{api::sync::ApiBuilder, Repo};
 use ndarray::{Array2, Axis};
 use ort::{
     execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider, ExecutionProvider},
@@ -52,7 +52,7 @@ impl OrtColbertEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename, data_filename) = {
-            let api = Api::new().unwrap();
+            let api = ApiBuilder::from_env().build().unwrap();
             let api = match revision {
                 Some(rev) => api.repo(Repo::with_revision(
                     hf_model_id.to_string(),

--- a/rust/src/embeddings/local/colpali.rs
+++ b/rust/src/embeddings/local/colpali.rs
@@ -43,7 +43,7 @@ pub struct ColPaliEmbedder {
 
 impl ColPaliEmbedder {
     pub fn new(model_id: &str, revision: Option<&str>) -> Result<Self, anyhow::Error> {
-        let api = hf_hub::api::sync::Api::new()?;
+        let api = hf_hub::api::sync::ApiBuilder::from_env().build()?;
         let repo: hf_hub::api::sync::ApiRepo = match revision {
             Some(rev) => api.repo(hf_hub::Repo::with_revision(
                 model_id.to_string(),

--- a/rust/src/embeddings/local/colpali_ort.rs
+++ b/rust/src/embeddings/local/colpali_ort.rs
@@ -31,7 +31,7 @@ impl OrtColPaliEmbedder {
         revision: Option<&str>,
         path_in_repo: Option<&str>,
     ) -> Result<Self, E> {
-        let api = hf_hub::api::sync::Api::new()?;
+        let api = hf_hub::api::sync::ApiBuilder::from_env().build()?;
         let repo: hf_hub::api::sync::ApiRepo = match revision {
             Some(rev) => api.repo(hf_hub::Repo::with_revision(
                 model_id.to_string(),

--- a/rust/src/embeddings/local/colsmol.rs
+++ b/rust/src/embeddings/local/colsmol.rs
@@ -21,7 +21,7 @@ pub struct ColSmolEmbedder {
 
 impl ColSmolEmbedder {
     pub fn new(model_id: &str, revision: Option<&str>) -> Result<Self, anyhow::Error> {
-        let api = hf_hub::api::sync::Api::new()?;
+        let api = hf_hub::api::sync::ApiBuilder::from_env().build()?;
         let repo: hf_hub::api::sync::ApiRepo = match revision {
             Some(rev) => api.repo(hf_hub::Repo::with_revision(
                 model_id.to_string(),

--- a/rust/src/embeddings/local/ort_bert.rs
+++ b/rust/src/embeddings/local/ort_bert.rs
@@ -9,7 +9,7 @@ use crate::embeddings::utils::{get_type_ids_ndarray, tokenize_batch_ndarray};
 
 use crate::Dtype;
 use anyhow::Error as E;
-use hf_hub::api::sync::Api;
+use hf_hub::api::sync::ApiBuilder;
 use hf_hub::Repo;
 use ndarray::prelude::*;
 use ort::execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider, ExecutionProvider};
@@ -62,7 +62,7 @@ impl OrtBertEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
+            let api = ApiBuilder::from_env().build().unwrap();
             let api = match revision {
                 Some(rev) => api.repo(Repo::with_revision(
                     hf_model_id.to_string(),
@@ -418,7 +418,7 @@ impl OrtSparseBertEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
+            let api = ApiBuilder::from_env().build().unwrap();
             let api = match revision {
                 Some(rev) => api.repo(Repo::with_revision(
                     hf_model_id.to_string(),

--- a/rust/src/embeddings/local/ort_colsmol.rs
+++ b/rust/src/embeddings/local/ort_colsmol.rs
@@ -34,7 +34,7 @@ impl OrtColSmolEmbedder {
         revision: Option<&str>,
         path_in_repo: Option<&str>,
     ) -> Result<Self, E> {
-        let api = hf_hub::api::sync::Api::new()?;
+        let api = hf_hub::api::sync::ApiBuilder::from_env().build()?;
         let repo: hf_hub::api::sync::ApiRepo = match revision {
             Some(rev) => api.repo(hf_hub::Repo::with_revision(
                 model_id.to_string(),

--- a/rust/src/embeddings/local/ort_jina.rs
+++ b/rust/src/embeddings/local/ort_jina.rs
@@ -6,7 +6,7 @@ use crate::embeddings::embed::EmbeddingResult;
 use crate::embeddings::utils::tokenize_batch_ndarray;
 use crate::Dtype;
 use anyhow::Error as E;
-use hf_hub::api::sync::Api;
+use hf_hub::api::sync::ApiBuilder;
 use hf_hub::Repo;
 use ndarray::prelude::*;
 use std::sync::RwLock;
@@ -63,7 +63,7 @@ impl OrtJinaEmbedder {
         };
 
         let (_, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
+            let api = ApiBuilder::from_env().build().unwrap();
             let api = match revision {
                 Some(rev) => api.repo(Repo::with_revision(
                     hf_model_id.to_string(),

--- a/rust/src/file_processor/audio/audio_processor.rs
+++ b/rust/src/file_processor/audio/audio_processor.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use anyhow::{Error as E, Result};
 use candle_core::{Device, IndexOp, Tensor};
 use candle_nn::{ops::softmax, VarBuilder};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 use rand::{
     distr::{weighted::WeightedIndex, Distribution},
     SeedableRng,
@@ -458,7 +458,7 @@ pub fn build_model(
         (None, None) => (default_model, default_revision),
     };
 
-    let api = Api::new()?;
+    let api = ApiBuilder::from_env().build()?;
     let repo = api.repo(Repo::with_revision(
         model_id.to_string(),
         RepoType::Model,

--- a/rust/src/models/idefics3/array_processing.rs
+++ b/rust/src/models/idefics3/array_processing.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{Error, Ok};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 use image::{imageops::FilterType, DynamicImage, GenericImageView, RgbImage};
 use ndarray::{s, Array2};
 use regex::Regex;
@@ -65,7 +65,7 @@ impl Idefics3ImageProcessor {
     }
 
     pub fn from_pretrained(model_id: &str) -> Result<Self, anyhow::Error> {
-        let api = Api::new()?;
+        let api = ApiBuilder::from_env().build()?;
         let repo = api.repo(Repo::new(model_id.to_string(), RepoType::Model));
         let config_file = repo.get("preprocessor_config.json").unwrap();
         let processor: Idefics3ImageProcessor =
@@ -692,7 +692,7 @@ fn normalize(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hf_hub::api::sync::Api;
+    use hf_hub::api::sync::ApiBuilder;
     use hf_hub::{Repo, RepoType};
     use image::RgbImage;
 
@@ -701,7 +701,7 @@ mod tests {
         let image = image::open("/home/akshay/projects/EmbedAnything/test.jpg").unwrap();
         let image_array = image.to_rgb8().into_raw();
 
-        let api = Api::new().unwrap();
+        let api = ApiBuilder::from_env().build().unwrap();
         let repo = api.repo(Repo::new(
             "onnx-community/colSmol-256M-ONNX".to_string(),
             RepoType::Model,

--- a/rust/src/models/idefics3/tensor_processing.rs
+++ b/rust/src/models/idefics3/tensor_processing.rs
@@ -1,5 +1,5 @@
 use candle_core::{DType, Device, Tensor};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 use image::{imageops::FilterType, DynamicImage, GenericImageView, RgbImage};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -503,7 +503,7 @@ impl Idefics3ImageProcessor {
     }
 
     pub fn from_pretrained(model_id: &str) -> Result<Self, anyhow::Error> {
-        let api = Api::new()?;
+        let api = ApiBuilder::from_env().build()?;
         let repo = api.repo(Repo::new(model_id.to_string(), RepoType::Model));
         let config_file = repo.get("preprocessor_config.json")?;
         let processor: Idefics3ImageProcessor =
@@ -525,7 +525,7 @@ pub struct Idefics3Processor {
 impl Idefics3Processor {
     pub fn from_pretrained(model_id: &str) -> anyhow::Result<Self> {
         let image_processor = Idefics3ImageProcessor::from_pretrained(model_id)?;
-        let api = Api::new()?;
+        let api = ApiBuilder::from_env().build()?;
         let repo = api.repo(Repo::new(model_id.to_string(), RepoType::Model));
 
         let processor_config_file = repo.get("processor_config.json")?;

--- a/rust/src/reranker/model.rs
+++ b/rust/src/reranker/model.rs
@@ -2,7 +2,7 @@ use std::sync::RwLock;
 
 use anyhow::{Error as E, Result};
 use candle_core::{Device, Tensor};
-use hf_hub::{api::sync::Api, Repo};
+use hf_hub::{api::sync::ApiBuilder, Repo};
 use ndarray::Array2;
 use ort::{
     execution_providers::{CUDAExecutionProvider, CoreMLExecutionProvider, ExecutionProvider},
@@ -41,7 +41,7 @@ impl Reranker {
         path_in_repo: Option<&str>,
     ) -> Result<Self, E> {
         let (config_filename, tokenizer_filename, weights_filename, tokenizer_config_filename) = {
-            let api = Api::new().unwrap();
+            let api = ApiBuilder::from_env().build().unwrap();
             let api = match revision {
                 Some(rev) => api.repo(Repo::with_revision(
                     model_id.to_string(),


### PR DESCRIPTION
Change `Api::new()` into `ApiBuilder::from_env().build()`. This fixes cases not handled in PR #179.

You can see in the [source code](https://docs.rs/hf-hub/0.4.2/src/hf_hub/api/sync.rs.html#441-443) that `Api::new()` is simply a call to `ApiBuilder::new().build()`. To opt-in for supporting environment variables `HF_HUB` and `HF_ENDPOINT`, we must explicitly use `ApiBuilder::from_env().build()` for all API calls.


Affected files are as follows:

- rust/src/
    - embeddings/local/
    - clip.rs: L206
    - colbert.rs: L55
    - colpali.rs: L46
    - colpali_ort.rs: L34
    - colsmol.rs: L24
    - ort_bert.rs: L65, L421
    - ort_colsmol.rs: L37
    - ort_jina.rs: L66
  - file_processor/audio/audio_processor.rs: L461
  - models/idefics3/
    - array_processing.rs: L68, L704
    - tensor_processing.rs: L506, L528
  - reranker/model.rs: L44

Tested that it works as follows.

```bash
export HF_HOME=/tmp/hf_home

hf cache scan
# Cache directory not found: /tmp/hf_home/hub

# trigger local caching
python -c 'from embed_anything import Reranker, Dtype; Reranker.from_pretrained("zhiqing/Qwen3-Reranker-0.6B-ONNX", dtype=Dtype.F32)'

hf cache scan
# REPO ID                          REPO TYPE SIZE ON DISK NB FILES LAST_ACCESSED     LAST_MODIFIED     REFS LOCAL PATH              
# -------------------------------- --------- ------------ -------- ----------------- ----------------- ---- ----------------------------------------------------------
# zhiqing/Qwen3-Reranker-0.6B-ONNX model             1.2G        4 a few seconds ago a few seconds ago main /tmp/hf_home/hub/models--zhiqing--Qwen3-Reranker-0.6B-ONNX
# 
# Done in 0.0s. Scanned 1 repo(s) for a total of 1.2G.
```