### PR TITLE
Fix: `pyi` add missing `staticmethod` decorator and remove duplicate declaration

### DIFF
--- a/python/python/embed_anything/_embed_anything.pyi
+++ b/python/python/embed_anything/_embed_anything.pyi
@@ -836,23 +836,6 @@ class EmbeddingModel:
             A list of EmbedData objects.
         """
 
-    def embed_webpage(
-        self,
-        url: str,
-        config: TextEmbedConfig | None = None,
-        adapter: Adapter | None = None,
-    ) -> list[EmbedData]:
-        """
-        Embeds the given webpage and returns a list of EmbedData objects.
-
-        Args:
-            url: The URL of the webpage to embed.
-            config: The configuration for the embedding.
-            adapter: The adapter for the embedding.
-
-        Returns:
-            A list of EmbedData objects.
-        """
 
 class AudioDecoderModel:
     """
@@ -1012,5 +995,3 @@ class ONNXModel(Enum):
     SPLADEPPENV1 = "SPLADEPPENV1"
 
     SPLADEPPENV2 = "SPLADEPPENV2"
-
-    ModernBERTBase = "ModernBERTBase"


### PR DESCRIPTION
This PR fixes some issues where type checkers complain about.

#### Constructor typed as instance method

<img width="1045" height="357" alt="Image" src="https://github.com/user-attachments/assets/ebb0fea6-d2ee-4a25-b75d-af90684374d1" />

<img width="1181" height="161" alt="Image" src="https://github.com/user-attachments/assets/b64a199c-6232-4107-9ef4-f51bbe505388" />

#### Duplicate declarations

<img width="628" height="210" alt="Image" src="https://github.com/user-attachments/assets/a13c38ea-d77b-47e0-8703-145fcb0dd5ee" />

<img width="742" height="138" alt="Image" src="https://github.com/user-attachments/assets/b870826b-abee-4d09-af79-ca2c274965ab" />