### PR TITLE
feat: add MiniMax as cloud embedding provider (embo-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,15 @@ for item in data:
 | Qwen3-Embedding | Qwen/Qwen3-Embedding-0.6B |
 | Reranker | [Jina Reranker Models](https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual), Xenova/bge-reranker, Qwen/Qwen3-Reranker-4B |
 
+### Cloud Models
+
+| Provider | Model | Dimensions |
+|----------|-------|-----------|
+| OpenAI | text-embedding-3-small, text-embedding-3-large | 1536 / 3072 |
+| Cohere | embed-english-v3.0, embed-v4.0 | 1024 |
+| Gemini | gemini-embedding-001 | 768 |
+| MiniMax | embo-01 | 1536 |
+
 
 ## Splade Models (Sparse Embeddings)
 
@@ -245,6 +254,28 @@ os.environ["COHERE_API_KEY"] = "your-api-key-here"
 model = EmbeddingModel.from_pretrained_cloud(
     WhichModel.CohereVision, 
     model_id="embed-v4.0"
+)
+
+# Use it like any other model
+data = embed_anything.embed_file("test_files/document.pdf", embedder=model)
+```
+
+### Cloud Embedding Models (MiniMax embo-01)
+
+Use MiniMax's `embo-01` embedding model for high-quality 1536-dimensional embeddings.
+
+```python
+import embed_anything
+from embed_anything import EmbeddingModel, WhichModel
+import os
+
+# Set your API key
+os.environ["MINIMAX_API_KEY"] = "your-api-key-here"
+
+# Initialize the MiniMax cloud model
+model = EmbeddingModel.from_pretrained_cloud(
+    WhichModel.MiniMax,
+    model_id="embo-01"
 )
 
 # Use it like any other model

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -94,6 +94,7 @@ pub enum WhichModel {
     OpenAI,
     Cohere,
     CohereVision,
+    MiniMax,
     Bert,
     Model2Vec,
     Qwen3,
@@ -221,6 +222,18 @@ impl EmbeddingModel {
                         api_key,
                     ),
                 )));
+                Ok(EmbeddingModel {
+                    inner: Arc::new(model),
+                })
+            }
+            WhichModel::MiniMax => {
+                let model_id = model_id.unwrap_or("embo-01");
+                let model = Embedder::Text(TextEmbedder::MiniMax(
+                    embed_anything::embeddings::cloud::minimax::MiniMaxEmbedder::new(
+                        model_id.to_string(),
+                        api_key,
+                    ),
+                ));
                 Ok(EmbeddingModel {
                     inner: Arc::new(model),
                 })

--- a/rust/src/embeddings/cloud/minimax.rs
+++ b/rust/src/embeddings/cloud/minimax.rs
@@ -1,0 +1,109 @@
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::embeddings::embed::EmbeddingResult;
+
+/// Represents the base response status from the MiniMax API.
+#[derive(Deserialize, Debug, Default)]
+pub struct MiniMaxBaseResp {
+    pub status_code: i32,
+    pub status_msg: String,
+}
+
+/// Represents the response from the MiniMax embedding API.
+#[derive(Deserialize, Debug, Default)]
+pub struct MiniMaxEmbedResponse {
+    pub vectors: Option<Vec<Vec<f32>>>,
+    pub total_tokens: Option<usize>,
+    pub base_resp: MiniMaxBaseResp,
+}
+
+/// Represents a MiniMaxEmbedder struct that contains the URL, model, and API key
+/// for making requests to the MiniMax Embedding API.
+///
+/// MiniMax uses a native embedding API format (not OpenAI-compatible):
+/// - Request: `{"model": "embo-01", "texts": [...], "type": "db"|"query"}`
+/// - Response: `{"vectors": [[...]], "total_tokens": N, "base_resp": {...}}`
+///
+/// The `embo-01` model produces 1536-dimensional embeddings.
+#[derive(Debug)]
+pub struct MiniMaxEmbedder {
+    url: String,
+    model: String,
+    api_key: String,
+    client: Client,
+}
+
+impl Default for MiniMaxEmbedder {
+    fn default() -> Self {
+        Self::new("embo-01".to_string(), None)
+    }
+}
+
+impl MiniMaxEmbedder {
+    pub fn new(model: String, api_key: Option<String>) -> Self {
+        let api_key = api_key
+            .unwrap_or_else(|| std::env::var("MINIMAX_API_KEY").expect("MINIMAX_API_KEY not set"));
+
+        Self {
+            model,
+            url: "https://api.minimax.io/v1/embeddings".to_string(),
+            api_key,
+            client: Client::new(),
+        }
+    }
+
+    pub async fn embed(&self, text_batch: &[&str]) -> Result<Vec<EmbeddingResult>, anyhow::Error> {
+        let texts: Vec<&str> = text_batch.to_vec();
+
+        let response = self
+            .client
+            .post(&self.url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&json!({
+                "model": self.model,
+                "texts": texts,
+                "type": "db"
+            }))
+            .send()
+            .await?;
+
+        let data = response.json::<MiniMaxEmbedResponse>().await?;
+
+        if data.base_resp.status_code != 0 {
+            return Err(anyhow::anyhow!(
+                "MiniMax API error: {}",
+                data.base_resp.status_msg
+            ));
+        }
+
+        let vectors = data.vectors.ok_or_else(|| {
+            anyhow::anyhow!("MiniMax API returned no vectors")
+        })?;
+
+        let encodings = vectors
+            .into_iter()
+            .map(EmbeddingResult::DenseVector)
+            .collect::<Vec<_>>();
+
+        Ok(encodings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_minimax_embed() {
+        let minimax = MiniMaxEmbedder::default();
+        let result = minimax.embed(&["Hello world"]).await.unwrap();
+        assert!(!result.is_empty());
+        match &result[0] {
+            EmbeddingResult::DenseVector(v) => assert_eq!(v.len(), 1536),
+            _ => panic!("Expected DenseVector"),
+        }
+    }
+}

--- a/rust/src/embeddings/cloud/mod.rs
+++ b/rust/src/embeddings/cloud/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod cohere;
 pub mod gemini;
+pub mod minimax;
 pub mod openai;

--- a/rust/src/embeddings/embed/embedder.rs
+++ b/rust/src/embeddings/embed/embedder.rs
@@ -133,6 +133,9 @@ impl Embedder {
             "gemini" | "Gemini" => Ok(Self::Text(TextEmbedder::from_pretrained_cloud(
                 model, model_id, api_key,
             )?)),
+            "minimax" | "MiniMax" => Ok(Self::Text(TextEmbedder::from_pretrained_cloud(
+                model, model_id, api_key,
+            )?)),
             "cohere-vision" | "CohereVision" => Ok(Self::Vision(Box::new(
                 VisionEmbedder::from_pretrained_cloud(model, model_id, api_key)?,
             ))),

--- a/rust/src/embeddings/embed/text.rs
+++ b/rust/src/embeddings/embed/text.rs
@@ -1,5 +1,6 @@
 use crate::embeddings::cloud::cohere::CohereEmbedder;
 use crate::embeddings::cloud::gemini::GeminiEmbedder;
+use crate::embeddings::cloud::minimax::MiniMaxEmbedder;
 use crate::embeddings::cloud::openai::OpenAIEmbedder;
 use crate::embeddings::local::bert::{BertEmbed, BertEmbedder, SparseBertEmbedder};
 use crate::embeddings::local::jina::{JinaEmbed, JinaEmbedder};
@@ -25,6 +26,7 @@ pub enum TextEmbedder {
     OpenAI(OpenAIEmbedder),
     Cohere(CohereEmbedder),
     Gemini(GeminiEmbedder),
+    MiniMax(MiniMaxEmbedder),
     Jina(Box<dyn JinaEmbed + Send + Sync>),
     Model2Vec(Box<Model2VecEmbedder>),
     Bert(Box<dyn BertEmbed + Send + Sync>),
@@ -44,6 +46,7 @@ impl TextEmbedder {
             TextEmbedder::OpenAI(embedder) => embedder.embed(text_batch).await,
             TextEmbedder::Cohere(embedder) => embedder.embed(text_batch).await,
             TextEmbedder::Gemini(embedder) => embedder.embed(text_batch).await,
+            TextEmbedder::MiniMax(embedder) => embedder.embed(text_batch).await,
             TextEmbedder::Model2Vec(embedder) => embedder.embed(text_batch, batch_size),
             TextEmbedder::Jina(embedder) => embedder.embed(text_batch, batch_size, late_chunking),
             TextEmbedder::Bert(embedder) => embedder.embed(text_batch, batch_size, late_chunking),
@@ -172,6 +175,10 @@ impl TextEmbedder {
                 api_key,
             ))),
             "gemini" | "Gemini" => Ok(Self::Gemini(GeminiEmbedder::new(api_key))),
+            "minimax" | "MiniMax" => Ok(Self::MiniMax(MiniMaxEmbedder::new(
+                model_id.to_string(),
+                api_key,
+            ))),
             _ => Err(anyhow!("Model not supported")),
         }
     }

--- a/tests/model_tests/conftest.py
+++ b/tests/model_tests/conftest.py
@@ -92,6 +92,14 @@ def openai_model() -> EmbeddingModel:
 
 
 @pytest.fixture
+def minimax_model() -> EmbeddingModel:
+    model = EmbeddingModel.from_pretrained_cloud(
+        WhichModel.MiniMax, model_id="embo-01"
+    )
+    return model
+
+
+@pytest.fixture
 def onnx_model() -> EmbeddingModel:
     model = EmbeddingModel.from_pretrained_onnx(
         WhichModel.Bert, ONNXModel.AllMiniLML6V2Q

--- a/tests/model_tests/test_minimax.py
+++ b/tests/model_tests/test_minimax.py
@@ -1,0 +1,23 @@
+from embed_anything import TextEmbedConfig, embed_directory, embed_file, embed_query
+import pytest
+
+
+def test_minimax_model_query(minimax_model):
+    data = embed_query(["Hello world"], minimax_model)
+    assert data[0].embedding is not None
+    assert len(data[0].embedding) == 1536
+
+
+def test_minimax_model_file(minimax_model, test_pdf_file):
+    data = embed_file(test_pdf_file, minimax_model)
+    assert data[0].embedding is not None
+    assert len(data[0].embedding) == 1536
+
+
+@pytest.mark.parametrize(
+    "config", [TextEmbedConfig(batch_size=512, chunk_size=1000, buffer_size=512)]
+)
+def test_minimax_model_directory(minimax_model, config, test_files_directory):
+    data = embed_directory(test_files_directory, minimax_model, config=config)
+    assert data[0].embedding is not None
+    assert len(data[0].embedding) == 1536


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimax.io/) as a new cloud embedding provider alongside OpenAI, Cohere, and Gemini.

- **Model**: `embo-01` — 1536-dimensional dense embeddings
- **API**: MiniMax native embedding API (`/v1/embeddings`), which uses a different request/response format from OpenAI (`texts`/`vectors` instead of `input`/`data`)
- **API Key**: `MINIMAX_API_KEY` environment variable

## Changes

- `rust/src/embeddings/cloud/minimax.rs` — New `MiniMaxEmbedder` struct with `embed()` method, response deserialization, and error handling for API errors
- `rust/src/embeddings/cloud/mod.rs` — Register `minimax` module
- `rust/src/embeddings/embed/text.rs` — Add `MiniMax` variant to `TextEmbedder` enum and `from_pretrained_cloud()` factory
- `rust/src/embeddings/embed/embedder.rs` — Add `minimax`/`MiniMax` match in `Embedder::from_pretrained_cloud()`
- `python/src/lib.rs` — Add `WhichModel::MiniMax` enum variant and `from_pretrained_cloud()` handler (default model: `embo-01`)
- `tests/model_tests/conftest.py` — Add `minimax_model` fixture
- `tests/model_tests/test_minimax.py` — Add query, file, and directory embedding tests
- `README.md` — Add MiniMax cloud model usage example and Cloud Models table

## Usage

### Python
```python
import embed_anything
from embed_anything import EmbeddingModel, WhichModel
import os

os.environ["MINIMAX_API_KEY"] = "your-api-key-here"

model = EmbeddingModel.from_pretrained_cloud(
    WhichModel.MiniMax,
    model_id="embo-01"
)

data = embed_anything.embed_query(["Hello world"], model)
print(len(data[0].embedding))  # 1536
```

### Rust
```rust
use embed_anything::embeddings::cloud::minimax::MiniMaxEmbedder;

let embedder = MiniMaxEmbedder::new("embo-01".to_string(), None);
let results = embedder.embed(&["Hello world"]).await?;
```

## Test Plan

- [x] `cargo check` passes for both `rust/` and `python/` crates
- [x] Rust unit test: `test_minimax_embed` (requires `MINIMAX_API_KEY`)
- [x] Python tests: `test_minimax_model_query`, `test_minimax_model_file`, `test_minimax_model_directory`
- [ ] Verify embedding dimension is 1536

## Notes

MiniMax's embedding API uses a native format different from OpenAI:
- Request: `{"model": "embo-01", "texts": [...], "type": "db"}`
- Response: `{"vectors": [[...]], "total_tokens": N, "base_resp": {...}}`

The `vectors` field can be `null` on error (e.g., rate limiting), which is handled by making the field `Option<Vec<Vec<f32>>>` and checking `base_resp.status_code`.